### PR TITLE
MFCX: Adjusting Readme.md to remove exercise branch placeholder

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,6 @@
-# liferay-course-client-extensions Repository
+# Mastering Frontend Liferay Client Extensions
 
-This repository contains the Liferay Course Client Extension materials.
-
-The main branch is the starting point for the course, and the other branches have the results from the end of the module exercises.
+This repository contains the Mastering Frontend Liferay Client Extensions course materials.
 
 ## Table of Contents
 
@@ -55,13 +53,3 @@ Once you have prepared your Liferay bundle, you can start and stop it using the 
    This command will stop the Liferay server, freeing up system resources.
 
 By following these steps, you can effectively manage the lifecycle of your Liferay bundle, ensuring a smooth development and testing process.
-
-
-
-
-
-## Exercise XX: XXXXXXXXXXXXXXXX
-
-In this exercise, you will learn how to add data models to enhance the clarity of the distributor solution. This involves creating and configuring the necessary data structures to support the application's functionality. Follow the steps outlined in the course materials to complete this exercise successfully.
-
-The solution for this exercise is under the `exercise-01` branch.


### PR DESCRIPTION
Removing the MFCX Readme.md placeholder description about exercise branches (along with setting a more user-friendly title).